### PR TITLE
Fixed the timezone issue at Bullhead city, AZ

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-var tiles = require('./lib/timezones.json');
+var tiles = Object.assign(
+    require('./lib/timezones.json'),
+    require('./lib/timezones-corrected.json')
+);
 var tilebelt = require('@mapbox/tilebelt');
 var moment = require('moment-timezone');
 var ss = require('simple-statistics');

--- a/lib/timezones-corrected.json
+++ b/lib/timezones-corrected.json
@@ -1,0 +1,3 @@
+{
+  "46/101/8":"America/Phoenix"
+}

--- a/test/timespace.test.js
+++ b/test/timespace.test.js
@@ -227,3 +227,17 @@ test('check higher zoom levels', function(t) {
 
   t.end();
 });
+
+test('check zone at bullhead city', function(t) {
+    var timestamp = Date.now();
+    var point = [-114.525379, 35.137396];
+
+    if (z === 8) {
+        var expected = moment.tz(new Date(timestamp), 'America/Phoenix');
+        t.equal(ts.getFuzzyLocalTimeFromPoint(timestamp, point).tz(), expected.tz());
+    } else {
+        t.true(ts.getFuzzyLocalTimeFromPoint(timestamp, point)._z.name.indexOf('/') > 0);
+    }
+
+    t.end();
+});


### PR DESCRIPTION
- As the timespace repo is no longer maintained, the fix for the issue https://github.com/mapbox/timespace/issues/9 is being introduced here.
- The original `timezones.json` is a auto-generated one, so changing the tile value in this file is not viable.
- So a new file `timezones-corrected.json` has been created. Any other locations identified in future can be added to the same.